### PR TITLE
Add scheduling, codeowners, small readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # renovate-config
 
-Those are Anaconda's global default configurations for renovate. To use the `default.json` configuration, put the following content in your `renovate.json` file:
+These are Anaconda's global default configurations for renovate. To use the `default.json` configuration, put the following content in your local repository's `renovate.json` file:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ These are Anaconda's global default configurations for renovate. To use the `def
 ```
 
 Check [docs.renovatebot.com/config-presets](https://docs.renovatebot.com/config-presets/) for details on config presets.
+
+# Customizing local repo config
+
+More to come..

--- a/default.json
+++ b/default.json
@@ -9,5 +9,9 @@
   "labels": [
     "renovate"
   ],
-  "reviewersFromCodeOwners": "true"
+  "reviewersFromCodeOwners": "true",
+  "timezone": "America/Chicago",
+  "schedule": [
+    "before 2am on Monday"
+  ]
 }

--- a/default.json
+++ b/default.json
@@ -10,8 +10,8 @@
     "renovate"
   ],
   "reviewersFromCodeOwners": "true",
-  "timezone": "America/Chicago",
+  "timezone": "UTC",
   "schedule": [
-    "before 2am on Monday"
+    "before 6am on Monday"
   ]
 }


### PR DESCRIPTION
Looking at the documentation more closely, I'm not entirely sure this is structured correctly. 

https://docs.renovatebot.com/config-presets/#example-configs

I guess I'm not that sure of the relationship between this file and the local repo's renovate.json - ie, what's the best way to allow teams to override defaults? Some guidance would be appreciated.