### PR TITLE
Codeowners and checks

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,19 @@
+name: Validate renovate config
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@fb9b41c5e259e46902369fc06f8c23f6453a82c6 # renovate: tag=v0.0.8

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @anaconda/anaconda-devops will be requested for
+# review when someone opens a pull request.
+*       @anaconda/anaconda-devops


### PR DESCRIPTION
This adds a `CODEOWNERS` file and makes use of `renovate-config-validator` to check that the configs we write are valid.