### PR TITLE
feat: limit number of PRs to 10 at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ To use the `default.json` configuration, put the following content in your local
 [This default configuration](default.json) does the following:
 
 * Uses the recommended base config by renovate (`extends[config:base]`)
-* Disables rate limiting: number of Open PRs is unlimited, number of PRs opened per hour is unlimited: (`extends[:disableRateLimiting]`)
+* Set number of Open PRs to 10 to not bury people in PRs: (`prConcurrentLimit`)
+* Do not limit number of PRs opened per hour: (`prHourlyLimit`)
 * Pins GitHub actions by digest, but add the tag it’s pinned to as comment (`extends[helpers:pinGitHubActionDigests]`)
 * Enables the [pre-commit manager](https://docs.renovatebot.com/modules/manager/pre-commit/) that is in beta (`pre-commit` section)
 * Adds `renovate` as label to all Pull Requests (`labels` section)

--- a/default.json
+++ b/default.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":disableRateLimiting",
     ":rebaseStalePrs",
     "helpers:pinGitHubActionDigests"
   ],
@@ -11,6 +10,8 @@
   "labels": [
     "renovate"
   ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
   "reviewersFromCodeOwners": "true",
   "timezone": "UTC",
   "schedule": [


### PR DESCRIPTION
This gets a reasonable amount of dependencies upgraded at least every week while not burying maintainers in PRs.