### PR TITLE
feat: improve PR number limits using only 1 template

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    ":prConcurrentLimit10",
     ":rebaseStalePrs",
     "helpers:pinGitHubActionDigests"
   ],
@@ -10,8 +11,6 @@
   "labels": [
     "renovate"
   ],
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 0,
   "reviewersFromCodeOwners": "true",
   "timezone": "UTC",
   "schedule": [


### PR DESCRIPTION
This moves from setting the options directly to using a template. It also removes the `prHourlyLimit` as this is the default config.