### PR TITLE
fix: override hourly limit from base template

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":prConcurrentLimit10",
+    ":prHourlyLimitNone",
     ":rebaseStalePrs",
     "helpers:pinGitHubActionDigests"
   ],


### PR DESCRIPTION
The base template limits to two PRs per hour. As we have a limit of 10 in total, this can be lifted.