### PR TITLE
docs: update documentation to point directly to the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,7 @@ To use the `default.json` configuration, put the following content in your local
 
 :warning: This configuration will change with the best practices Anaconda uses. If you want to review changes before applying them, [pin your extension](https://docs.renovatebot.com/config-presets/#github).
 
-[This default configuration](default.json) does the following:
-
-* Uses the recommended base config by renovate (`extends[config:base]`)
-* Set number of Open PRs to 10 to not bury people in PRs: (`prConcurrentLimit`)
-* Do not limit number of PRs opened per hour: (`prHourlyLimit`)
-* Pins GitHub actions by digest, but add the tag it’s pinned to as comment (`extends[helpers:pinGitHubActionDigests]`)
-* Enables the [pre-commit manager](https://docs.renovatebot.com/modules/manager/pre-commit/) that is in beta (`pre-commit` section)
-* Adds `renovate` as label to all Pull Requests (`labels` section)
-* Automatically sets Pull Request reviewers from the CODEOWNERS file if it exists (`reviewersFromCodeOwners`)
-* Rebases PRs that are behind the target branch to ensure tests run against up-to-date config. (`extends[:rebaseStalePrs]`)
-* Sets the timezone to UTC (`timezone`)
-* Runs before 6am UTC each Monday (`schedule`). This timeframe makes renvoate run outside of business hours for both our US and European teams.
+[This default configuration](default.json) has a `description` list that will give you an overview over the settings we use by default.
 
 ### Anaconda extensions
 


### PR DESCRIPTION
The documentation is outdated as I forgot to change it with the last updates of the `default.json` file. By pointing directly to the description, this won’t be needed anymore.