### PR TITLE
fix: correctly enable semanticCommits

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,6 +42,6 @@
   "schedule": [
     "before 6am on Monday"
   ],
-  "semanticCommits": "true",
+  "semanticCommits": "enabled",
   "timezone": "UTC"
 }


### PR DESCRIPTION
"true" is not a valid value here. See https://docs.renovatebot.com/configuration-options/#semanticcommits