### PR TITLE
feat: add upgrades for go-version in GitHub actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,6 +35,15 @@
       "matchStrings": [
         "datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ]
+    },
+    {
+      "description": "Upgrade go version in a GitHub workflow",
+      "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "go-version:\\s(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "go"
     }
   ],
   "schedule": [

--- a/docs/github-workflow-go-version.md
+++ b/docs/github-workflow-go-version.md
@@ -1,0 +1,27 @@
+# GitHub workflow go-version
+
+Support to upgrade the Go version in a GitHub workflow (for e.g. the `actions/setup-go` action) is built-in. Renovate will automatically detect the `go-version` string.
+
+:warning: Ensure that there are **no quotes** around the version number.
+
+```yml
+name: Example for Go version uprades
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.1
+```


### PR DESCRIPTION
We use actions/setup-go in more and more places, e.g. for helm docs, for terraform docs etc.

This adds support to automatically detect and update those
