### PR TITLE
feat: add conda datasource with regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,6 +44,16 @@
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go"
+    },
+    {
+      "description": "Upgrade conde dependencies",
+      "fileMatch": [
+        "(^|/)environment.yml$"
+      ],
+      "matchStrings": [
+        "# renovate datasource=conda\\sdepName=(?<depName>.*?)\\s+- [a-z0-9]+==\"?(?<currentValue>.*)\"?"
+      ],
+      "datasourceTemplate": "conda"
     }
   ],
   "schedule": [

--- a/docs/conda-environment.md
+++ b/docs/conda-environment.md
@@ -1,0 +1,22 @@
+# Conda environment.yml
+
+Renovate has a conda datasource already, so we can manually tag dependencies to use it.
+
+To do so, you need to add the line `# renovate datasource=conda depName=${channel}/${dependency}` *directly above* the line with your dependency.
+
+Example:
+
+```yml
+name: your-project
+channels:
+  - defaults
+dependencies:
+  # renovate datasource=conda depName=main/pytest
+  - pytest
+  # renovate datasource=conda depName=main/pytest-cov
+  - pytest-cov
+  # renovate datasource=conda depName=main/coverage
+  - coverage
+  # renovate datasource=conda depName=main/yapf
+  - yapf==0.31.0
+```


### PR DESCRIPTION
This adds a regex manager for the conda datasource which can be used as we don’t have a conda manager yet.
