### PR TITLE
[CORE-984] Ignore commits of old renovate instance

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,6 +26,7 @@
   "prHourlyLimit": 0,
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": "true",
+  "gitIgnoredAuthors": ["anaconda-renovate-bot <anaconda-renovate-bot@anaconda.com>"],
   "regexManagers": [
     {
       "description": "Upgrade arbitrary dependencies in a Dockerfile declared via ENV variables",


### PR DESCRIPTION
This way the new renovate instance does not consider PRs of the old instance to be modified.