### PR TITLE
feat/ignore anaconda bot

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,7 +26,7 @@
   "prHourlyLimit": 0,
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": "true",
-  "gitIgnoredAuthors": ["anaconda-renovate-bot <anaconda-renovate-bot@anaconda.com>"],
+  "gitIgnoredAuthors": ["anaconda-renovate-bot@anaconda.com"],
   "regexManagers": [
     {
       "description": "Upgrade arbitrary dependencies in a Dockerfile declared via ENV variables",

--- a/default.json
+++ b/default.json
@@ -26,7 +26,10 @@
   "prHourlyLimit": 0,
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": "true",
-  "gitIgnoredAuthors": ["anaconda-renovate-bot@anaconda.com"],
+  "gitIgnoredAuthors": [
+    "anaconda-renovate-bot@anaconda.com",
+    "devops+anaconda-bot@anaconda.com"
+  ],
   "regexManagers": [
     {
       "description": "Upgrade arbitrary dependencies in a Dockerfile declared via ENV variables",


### PR DESCRIPTION
This PR contains two changes, it fixes a broken author ignore and adds one for the Anaconda Bot user.

This is useful since we use the Anaconda Bot user for automatic formatting on PRs and we want renovate to continue editing those.

- fix: make anaconda-renovate-bot author RFC5322 conformat
- feat: add anaconda-bot to ignored authors
