### PR TITLE
feat: include RedHat image version workaround

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,8 @@
     "group:monorepos",
     "group:recommended",
     "helpers:pinGitHubActionDigests",
-    "workarounds:typesNodeVersioning"
+    "workarounds:typesNodeVersioning",
+    "workarounds:supportRedHatImageVersion"
   ],
   "dependencyDashboard": true,
   "description": [


### PR DESCRIPTION
This configures our default preset to include the workaround for the RedHat image versioning.

RedHat uses non-semver-compliant tags to version certain images, these are set to use the correct versioning syntax with this change.
