### PR TITLE
feat: Extend conda env file regex

### DIFF
--- a/default.json
+++ b/default.json
@@ -53,7 +53,7 @@
     {
       "description": "Upgrade conda dependencies",
       "fileMatch": [
-        "(^|/)environment.ya?ml$"
+        "(^|/)environment(.*).ya?ml$"
       ],
       "matchStrings": [
         "# renovate datasource=conda\\sdepName=(?<depName>.*?)\\s+- [a-z0-9]+==\"?(?<currentValue>.*)\"?"

--- a/default.json
+++ b/default.json
@@ -53,7 +53,7 @@
     {
       "description": "Upgrade conda dependencies",
       "fileMatch": [
-        "(^|/)environment.yml$"
+        "(^|/)environment.ya?ml$"
       ],
       "matchStrings": [
         "# renovate datasource=conda\\sdepName=(?<depName>.*?)\\s+- [a-z0-9]+==\"?(?<currentValue>.*)\"?"


### PR DESCRIPTION
Extends the regex pattern for conda environment files to:

* Allow either `.yml` or `.yaml` extensions
* Allow any characters between the word `environment` and the extension (e.g. `environment-dev.yaml`)

I placed the `.*` inside a capture group, which will not be used. I wouldn't have done that, but I noticed the `.` is not escaped.

Potentially the regex should instead be: `(^|/)environment.*\.ya?ml$`