### PR TITLE
feat: Add datasource to commit message for regex managed packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,12 @@
     "Automatically set reviewers from CODEOWNERS",
     "Upgrade arbitrary dependencies in Dockerfiles when you mark them, [see the documentation for details](https://github.com/anaconda/renovate-config/blob/main/docs/Dockerfile.md)"
   ],
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "commitMessageTopic": "{{datasource}} dependency {{depName}}"
+    }
+  ],
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
This will update the config to add the datasource to the beginning of the generated commit message. This is useful to make the PR titles include the data source, in cases where it could be ambiguous.

See this example below from my test project where both `pypi` and `conda` packages are in the same `environment.yml` file:

![image](https://user-images.githubusercontent.com/11037737/235206633-0b4a9d7e-1a11-4592-940b-dcb68db17a4d.png)

https://github.com/lembas-project/renovate-test/issues/1