### PR TITLE
feat: Expanded conda regex

### DIFF
--- a/default.json
+++ b/default.json
@@ -52,9 +52,7 @@
     },
     {
       "description": "Upgrade conda dependencies",
-      "fileMatch": [
-        "(^|/)environment(.*).ya?ml$"
-      ],
+      "fileMatch": ["(^|/)environment(.*).ya?ml$"],
       "matchStrings": [
         "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
       ],

--- a/default.json
+++ b/default.json
@@ -57,6 +57,12 @@
         "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
       ],
       "datasourceTemplate": "conda"
+    },
+    {
+      "description": "Upgrade pypi dependencies inside conda environment files",
+      "fileMatch": ["(^|/)environment(.*).ya?ml$"],
+      "matchStrings": ["# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*==?(?<currentValue>.*)"],
+      "datasourceTemplate": "pypi"
     }
   ],
   "schedule": [

--- a/default.json
+++ b/default.json
@@ -56,7 +56,7 @@
         "(^|/)environment(.*).ya?ml$"
       ],
       "matchStrings": [
-        "# renovate datasource=conda\\sdepName=(?<depName>.*?)\\s+- [a-z0-9]+==\"?(?<currentValue>.*)\"?"
+        "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
       ],
       "datasourceTemplate": "conda"
     }

--- a/docs/conda-environment.md
+++ b/docs/conda-environment.md
@@ -4,7 +4,11 @@ Renovate has a conda datasource already, so we can manually tag dependencies to 
 
 To do so, you need to add the line `# renovate datasource=conda depName=${channel}/${dependency}` *directly above* the line with your dependency.
 
-Example:
+You can also capture pypi dependencies by placing the line `# renovate datasource=pypi` *directly above* the line with your dependency
+
+Note: You must specify the exact current version of your conda dependency before Renovate will recognize available upgrades
+
+## Example:
 
 ```yml
 name: your-project
@@ -18,5 +22,9 @@ dependencies:
   # renovate datasource=conda depName=main/coverage
   - coverage
   # renovate datasource=conda depName=main/yapf
-  - yapf==0.31.0
+  - yapf=0.31.0
+  - pip
+  - pip:
+    # renovate datasource=pypi
+    - uvicorn==0.17.6
 ```


### PR DESCRIPTION
This PR expands the conda regex manager configuration to do the following:

* Be a bit more flexible about whitespace in the renovate comment
* Allow either `=` or `==` for conda dependencies (conda uses a single `=`, but pip uses `==` so it's a common error)
* Allows capturing `pypi` dependencies that are specificed inside an `environment.yml` file.