### PR TITLE
fix: use colons like upstream does

### DIFF
--- a/default.json
+++ b/default.json
@@ -66,14 +66,18 @@
       "description": "Upgrade conda dependencies",
       "fileMatch": ["(^|/)environment(.*).ya?ml$"],
       "matchStrings": [
-        "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
+        "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?",
+        "# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
       ],
       "datasourceTemplate": "conda"
     },
     {
       "description": "Upgrade pypi dependencies inside conda environment files",
       "fileMatch": ["(^|/)environment(.*).ya?ml$"],
-      "matchStrings": ["# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"],
+      "matchStrings": [
+        "# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
+        "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
+      ],
       "datasourceTemplate": "pypi"
     },
     {
@@ -82,14 +86,14 @@
         ".tflint.hcl"
       ],
       "matchStrings": [
-        "# renovate datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s+version\\s+=\\s+\"(?<currentValue>.*)\""
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+version\\s+=\\s+\"(?<currentValue>.*)\""
       ]
     },
     {
       "description": "Upgrade arbitrary go module versions in Makefiles",
       "fileMatch": ["^Makefile"],
       "matchStrings": [
-        "# renovate:\\sdatasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
     }
   ],

--- a/docs/conda-environment.md
+++ b/docs/conda-environment.md
@@ -2,11 +2,13 @@
 
 Renovate has a conda datasource already, so we can manually tag dependencies to use it.
 
-To do so, you need to add the line `# renovate datasource=conda depName=${channel}/${dependency}` *directly above* the line with your dependency.
+To do so, you need to add the line `# renovate: datasource=conda depName=${channel}/${dependency}` *directly above* the line with your dependency.
 
-You can also capture pypi dependencies by placing the line `# renovate datasource=pypi` *directly above* the line with your dependency
+You can also capture pypi dependencies by placing the line `# renovate: datasource=pypi` *directly above* the line with your dependency
 
 Note: You must specify the exact current version of your conda dependency before Renovate will recognize available upgrades
+
+:information_source: This manager also supports the **deprecated notations** `# renovate datasource=conda` and `# renovate datasource=pypi` **without a colon**. Please add a colon wherever you find these to get be compatible with renovate upstream.
 
 ## Example:
 
@@ -15,16 +17,16 @@ name: your-project
 channels:
   - defaults
 dependencies:
-  # renovate datasource=conda depName=main/pytest
+  # renovate: datasource=conda depName=main/pytest
   - pytest
-  # renovate datasource=conda depName=main/pytest-cov
+  # renovate: datasource=conda depName=main/pytest-cov
   - pytest-cov
-  # renovate datasource=conda depName=main/coverage
+  # renovate: datasource=conda depName=main/coverage
   - coverage
-  # renovate datasource=conda depName=main/yapf
+  # renovate: datasource=conda depName=main/yapf
   - yapf=0.31.0
   - pip
   - pip:
-    # renovate datasource=pypi
+    # renovate: datasource=pypi
     - uvicorn==0.17.6
 ```

--- a/docs/tflint-plugins.md
+++ b/docs/tflint-plugins.md
@@ -6,7 +6,7 @@ Annotate your `.tflint.hcl` file as follows:
 ```hcl
 plugin "aws" {
     enabled = true
-    # renovate datasource=github-releases depName=terraform-linters/tflint-ruleset-aws
+    # renovate: datasource=github-releases depName=terraform-linters/tflint-ruleset-aws
     version = "0.20.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
## Description/Purpose

This adds configuration to detect `# renovate:` comments to managers that previously only detected it **without** the colon.
It removes the old configuration from managers that were added in #39 since these are not in use anywhere.

## Expected Impact

Upstream-like regexManager comments are supported everywhere.
