### PR TITLE
feat: set shellcheck-py versioning to loose

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,6 +36,12 @@
       "matchManagers": ["regex"],
       "matchPackageNames": ["terraform-linters/tflint-ruleset-aws"],
       "extractVersion": "^v(?<version>)"
+    },
+    {
+      "description": "shellcheck-py does not use semantic versioning",
+      "matchManagers": ["pre-commit"],
+      "matchDepNames": ["shellcheck-py/shellcheck-py"],
+      "versioning": "loose"
     }
   ],
   "pre-commit": {


### PR DESCRIPTION

## Description/Purpose

We use shellcheck-py for pre-commit in multiple locations, therefore
it makes sense to configure it here once for all repositories.

## Expected Impact

renovate updates shellcheck-py.
