### PR TITLE
chore: remove anaconda-renovate-bot from ignoredAuthors

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,7 +49,6 @@
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": true,
   "gitIgnoredAuthors": [
-    "anaconda-renovate-bot@anaconda.com",
     "devops+anaconda-bot@anaconda.com"
   ],
   "regexManagers": [


### PR DESCRIPTION

## Description/Purpose

We are no longer using this user for renovate, it can therefore be removed.

## Expected Impact
