### PR TITLE
Revert "chore: remove anaconda-renovate-bot from ignoredAuthors"

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,6 +49,7 @@
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": true,
   "gitIgnoredAuthors": [
+    "anaconda-renovate-bot@anaconda.com",
     "devops+anaconda-bot@anaconda.com"
   ],
   "regexManagers": [


### PR DESCRIPTION
Reverts anaconda/renovate-config#49.

We need to keep this for a while to ensure all old branches are "flushed". Since this piece of configuration does not hurt anyone, it does not matter if it stays for now.
Once all branches existing before 2023-08-01 are merged, we can remove this again.