### PR TITLE
feat: add preset for terraform modules

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   validate:
-    name: Validate renovate config
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ You can add presets to this repository. Please name them accordingly, e.g. `infr
 
 ```json
 {
-  "extends": ["github>anaconda/renovate-config"],
   "description": "Custom configuration for infrastructure team that will add other labels then the default",
   "labels": [
     "different-label"
@@ -55,11 +54,11 @@ To use this preset, you will then set the following in `renovate.json` in your r
 
 ```json
 {
-  "extends": ["github>anaconda/renovate-config:infrastructure"]
+  "extends": ["github>anaconda/renovate-config", "github>anaconda/renovate-config:infrastructure"]
 }
 ```
 
-This config will then get merged with the config in `default.json`. Settings you define in the team specific config will be merged with the default config.
+This config will then get merged with the config in `default.json`. Settings you define in the team specific config will be merged with the default config. In case of conflicting configuration, the config from the last `extends` entry is used.
 
 ## Customizing local repo config
 

--- a/terraformModule.json
+++ b/terraformModule.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Automerge CI and other helper depdenencies for terraform modules"
+  ],
+  "packageRules": [
+    {
+      "description": "Automatically merge minor updates for some managers",
+      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "regex"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description/Purpose

This can be used with terraform modules to configure them specifically for the Anaconda best practices.

## Expected Impact

Configuration updates can be made at one central place for all modules.