### PR TITLE
chore: remove tflint config

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,12 +30,6 @@
       "matchManagers": ["terraform"],
       "matchDepTypes": ["required_provider"],
       "rangeStrategy": "widen"
-    },
-    {
-      "description": "Remove 'v' from aws ruleset for tflint for the regex manager",
-      "matchManagers": ["regex"],
-      "matchPackageNames": ["terraform-linters/tflint-ruleset-aws"],
-      "extractVersion": "^v(?<version>)"
     }
   ],
   "pre-commit": {
@@ -79,15 +73,6 @@
         "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
       ],
       "datasourceTemplate": "pypi"
-    },
-    {
-      "description": "Upgrade tflint plugins. Version must be specified with double quotes",
-      "fileMatch": [
-        ".tflint.hcl"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+version\\s+=\\s+\"(?<currentValue>.*)\""
-      ]
     },
     {
       "description": "Upgrade arbitrary go module versions in Makefiles",

--- a/terraformModule.json
+++ b/terraformModule.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "description": "Automatically merge minor updates for some managers",
-      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "regex"],
+      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "regex", "tflint-plugin"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }


### PR DESCRIPTION
## Description/Purpose

This removes config for tflint since this is captured by the **tflint-plugin** manager by now.
Also adds automerging for tflint-plugin manager to the terraform module preset.


## Expected Impact
