### PR TITLE
feat: add go updating postUpdateOptions

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,10 @@
   "labels": [
     "renovate"
   ],
+  "postUpdateOptions": [
+    "gomodUpdateImportPaths",
+    "gomodTidy"
+  ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "rangeStrategy": "auto",


### PR DESCRIPTION
## Description/Purpose

With this change, updates to go modules will go much smoother:

- `gomodTidy` runs `go mod tidy`, which updates the `go.sum` file that contains the module hashes and cleans up the `go.mod` file
- `gomodUpdateImportPaths` updates import paths when module paths change, enabling major updates in one PR without manual intervention

## Expected Impact

Fewer manual touches needed for major updates of go modules.