### PR TITLE
feat: Add pattern to allow specifying custom PyPI URL

### DIFF
--- a/default.json
+++ b/default.json
@@ -74,7 +74,8 @@
       "fileMatch": ["(^|/)environment(.*).ya?ml$"],
       "matchStrings": [
         "# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
-        "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
+        "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
+        "# renovate: datasource=pypi\\s+registryUrl=(?<registryUrl>.*?)\\s*-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
       ],
       "datasourceTemplate": "pypi"
     },

--- a/default.json
+++ b/default.json
@@ -75,7 +75,7 @@
       "matchStrings": [
         "# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
         "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
-        "# renovate: datasource=pypi\\s+registryUrl=(?<registryUrl>.*?)\\s*-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
+        "# renovate: datasource=pypi\\s+registryUrl=(?<registryUrl>.*?)\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)"
       ],
       "datasourceTemplate": "pypi"
     },


### PR DESCRIPTION
## Description/Purpose

This allows us to reference custom packages at `https://pypi.anaconda.org/<user>/simple` or another similar custom PyPI index. An example usage is shown below

```yaml
dependencies:
- python=3.9
- pip
- pip:
  # The default will pull from https://pypi.org/simple
  # renovate: datasource=pypi
  - requests==2.0
  # But one can also specify the registryUrl manually
  # renovate: datasource=pypi registryUrl=https://pypi.anaconda.org/my-private-org/simple
  - my-internal-library==2.0.1
channels:
- defaults
```

## Expected Impact

This should just be an additive change, no unintended effects anticipated.

Here is the example regex testing:

[Regex101](https://regex101.com/r/8dVKZI/1)