### PR TITLE
fix: use 12:00 instead of noon

### DIFF
--- a/default.json
+++ b/default.json
@@ -88,7 +88,7 @@
     }
   ],
   "schedule": [
-    "every weekday before noon"
+    "every weekday before 12:00"
   ],
   "semanticCommits": "enabled",
   "timezone": "UTC"


### PR DESCRIPTION
## Description/Purpose
renovate somehow does not recognize "noon", use "12:00" instead.

## Expected Impact
