### PR TITLE
chore: update schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -88,7 +88,7 @@
     }
   ],
   "schedule": [
-    "every weekday before 12:00"
+    "every weekday"
   ],
   "semanticCommits": "enabled",
   "timezone": "UTC"


### PR DESCRIPTION
## Description/Purpose

This updates the schedule to be 24/5 (during weekdays) to allow for more
smooth operations and to get to all repositories at least once a day.
