### PR TITLE
Enable Docker digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "docker:pinDigests",
     "group:monorepos",
     "group:recommended",
     "helpers:pinGitHubActionDigests",


### PR DESCRIPTION
Docker container tags are not immutable versions, thus pinning them from e.g. node:14.15.1 to node:14.15.1@sha256:d938c1761e3afbae9242848ffbb95b9cc1cb0a24d889f8bd955204d347a7266e prevents "unnoticed" changes in containers.

This is especially relevant to all the external containers we use in helm charts or FROM statements, as somebody could replace a known good version with a bad one (supply chain attack).

The impact of the PR is from "FROM CONTAINER:$VERSION" statements in Dockerfiles to helm charts and values files.

It requires to also to make certain tags more explicit like from "debian:12-slim" to "debian:12.5-slim", to not have the digest changed without a version change. This can be done incrementally via the PRs that renovate anyways opens.

Renovate says "We recommend that you pin your Docker images to an exact digest". We can disable this any time globally or per repo / file, in case it is unwanted.

See also:
* https://docs.renovatebot.com/docker/#digest-pinning
* https://docs.renovatebot.com/presets-docker/#dockerpindigests

## Description/Purpose

## Expected Impact
