### PR TITLE
Add 'old' style git user to gitIgnoredAuthors'

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,6 +48,7 @@
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": true,
   "gitIgnoredAuthors": [
+    "anaconda-renovate[bot]@users.noreply.github.com",
     "anaconda-renovate-bot@anaconda.com",
     "devops+anaconda-bot@anaconda.com"
   ],


### PR DESCRIPTION
This was causing renovate to no longer identify previous commits as its own.  See-also https://anaconda.slack.com/archives/C010ZDG1ACB/p1721162321058809

## Description/Purpose

## Expected Impact
