### PR TITLE
Pin Serverless major version to < 4.x due to license changes

### DIFF
--- a/default.json
+++ b/default.json
@@ -87,6 +87,11 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
+    },
+    {
+      "description": "Pin Serverless to less than 4.x because of license changes.",
+      "matchDepNames": ["serverless"],
+      "allowedVersions": "< 4.0"
     }
   ],
   "schedule": [


### PR DESCRIPTION
I think this is right.

See one example of the serverless v4 renovate bump in https://github.com/anaconda-distribution/rocket-platform/pull/1250
Or in https://github.com/anaconda/lambdas/pull/607
