### PR TITLE
fix: disable docker:pinDigests for ArgoCD

### DIFF
--- a/default.json
+++ b/default.json
@@ -92,6 +92,13 @@
       "description": "Pin Serverless to less than 4.x because of license changes.",
       "matchDepNames": ["serverless"],
       "allowedVersions": "< 4.0"
+    },
+    {
+      "description": "This disables the config from docker:pinDigests for the argocd manager. See https://github.com/renovatebot/renovate/pull/30556, can be removed once renovate-ce has released a version that contains this config",
+      "matchManagers": [
+        "argocd"
+      ],
+      "pinDigests": false
     }
   ],
   "schedule": [


### PR DESCRIPTION
## Description/Purpose

See https://github.com/renovatebot/renovate/pull/30556 for details.

## Expected Impact

Fewer errors in the dependency dashboard.
