### PR TITLE
Include full Semver as comment when pinning actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,7 @@
     "docker:pinDigests",
     "group:monorepos",
     "group:recommended",
-    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
     "workarounds:typesNodeVersioning",
     "workarounds:supportRedHatImageVersion",
     "regexManagers:dockerfileVersions",


### PR DESCRIPTION
## Description/Purpose

The current pinning pins from e.g. `- uses: actions/checkout@v3` to `- uses: actions/checkout@8e5e7... # v3`

And further updates from `- uses: actions/checkout@8e5e7... # v3` to `- uses: actions/checkout@0d6c329 # v3`

All those PRs would lack any changelog information as without knowing the Semver more information cannot be added to the PR description.

This could be manually fixed by somebody adding a full Semver and renovate would from then on start to do changes like: `- uses: actions/checkout@8e5e7... # v3.1.1` to `- uses: actions/checkout@0d6c329 # v3.1.2` with full changelog in the PR description.

This can be made easier by avoiding the manual step via `"helpers:pinGitHubActionDigestsToSemver"`

For more context see:
* https://github.com/renovatebot/renovate/discussions/21901
* https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver

## Expected Impact
