### PR TITLE
Migrate renovate config(s) via pre-commit hook(s)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      #- id: pretty-format-json
+      #  args: [--autofix, --no-sort-keys]
+      - id: check-json
+      - id: check-yaml
       - id: trailing-whitespace
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.93.1
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]
+        files: \.(json|json5)$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
@@ -16,3 +27,8 @@ repos:
     hooks:
       - id: check-renovate
         name: validate renovate config
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      #- id: pretty-format-json
-      #  args: [--autofix, --no-sort-keys]
+      - id: pretty-format-json
+        args: [--autofix, --no-sort-keys]
       - id: check-json
       - id: check-yaml
       - id: trailing-whitespace

--- a/anaconda-installers.json
+++ b/anaconda-installers.json
@@ -11,7 +11,9 @@
         "Anaconda Distribution installer.",
         "This group will bundle all installer architectures into one PR."
       ],
-      "matchDatasources": ["custom.anaconda_installer"],
+      "matchDatasources": [
+        "custom.anaconda_installer"
+      ],
       "groupName": "Anaconda Distribution",
       "commitMessageTopic": "Anaconda Distribution",
       "separateMajorMinor": false
@@ -21,7 +23,9 @@
         "Miniconda installer.",
         "This group will bundle all installer architectures into one PR."
       ],
-      "matchDatasources": ["custom.miniconda_installer"],
+      "matchDatasources": [
+        "custom.miniconda_installer"
+      ],
       "groupName": "Miniconda",
       "commitMessageTopic": "Miniconda",
       "separateMajorMinor": false

--- a/default.json
+++ b/default.json
@@ -7,8 +7,8 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "workarounds:typesNodeVersioning",
     "workarounds:supportRedHatImageVersion",
-    "regexManagers:dockerfileVersions",
-    "regexManagers:githubActionsVersions"
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions"
   ],
   "dependencyDashboard": true,
   "description": [
@@ -43,10 +43,11 @@
     "anaconda-renovate-bot@anaconda.com",
     "devops+anaconda-bot@anaconda.com"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "description": "Upgrade go version in a GitHub workflow",
-      "fileMatch": ["(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
+      "managerFilePatterns": ["/(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$/"],
       "matchStrings": [
         "go-version:\\s(?<currentValue>.*)"
       ],
@@ -54,8 +55,9 @@
       "depNameTemplate": "go"
     },
     {
+      "customType": "regex",
       "description": "Upgrade conda dependencies",
-      "fileMatch": ["(^|/)environment(.*).ya?ml$"],
+      "managerFilePatterns": ["/(^|/)environment(.*).ya?ml$/"],
       "matchStrings": [
         "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?",
         "# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
@@ -63,8 +65,9 @@
       "datasourceTemplate": "conda"
     },
     {
+      "customType": "regex",
       "description": "Upgrade pypi dependencies inside conda environment files",
-      "fileMatch": ["(^|/)environment(.*).ya?ml$"],
+      "managerFilePatterns": ["/(^|/)environment(.*).ya?ml$/"],
       "matchStrings": [
         "# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
         "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
@@ -73,8 +76,9 @@
       "datasourceTemplate": "pypi"
     },
     {
+      "customType": "regex",
       "description": "Upgrade arbitrary go module versions in Makefiles",
-      "fileMatch": ["^Makefile"],
+      "managerFilePatterns": ["/^Makefile/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
@@ -82,7 +86,7 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "commitMessageTopic": "{{datasource}} dependency {{depName}}"
     },
     {

--- a/default.json
+++ b/default.json
@@ -34,7 +34,7 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "prBodyNotes": [
-    "<details><summary>renovate update details</summary><p>\n\n| Field       | Value             | \n|-------------|-------------------|\n| manager     | {{ manager }}     |\n| categories  | {{ categories }}  | \n| datasource  | {{ datasource }}  |\n| depName     | {{ depName }}     | \n| depType¹    | {{ depType }}     | \n| packageName | {{ packageName }} |\n| sourceUrl   | {{ sourceUrl }}   |\n| updateType  | {{ updateType }}  | \n| versioning  | {{ versioning }}  |\n\n¹ only available for some managers\n</p></details>"
+    "<details><summary>renovate update details</summary><p>\n\n| Field       | Value             | \n|-------------|-------------------|\n| manager     | {{ manager }}     |\n| categories  | {{ categories }}  | \n| datasource  | {{ datasource }}  |\n| depName     | {{ depName }}     | \n| depType\u00b9    | {{ depType }}     | \n| packageName | {{ packageName }} |\n| sourceUrl   | {{ sourceUrl }}   |\n| updateType  | {{ updateType }}  | \n| versioning  | {{ versioning }}  |\n\n\u00b9 only available for some managers\n</p></details>"
   ],
   "rangeStrategy": "auto",
   "reviewersFromCodeOwners": true,
@@ -47,7 +47,9 @@
     {
       "customType": "regex",
       "description": "Upgrade go version in a GitHub workflow",
-      "managerFilePatterns": ["/(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$/"],
+      "managerFilePatterns": [
+        "/(^workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$/"
+      ],
       "matchStrings": [
         "go-version:\\s(?<currentValue>.*)"
       ],
@@ -57,7 +59,9 @@
     {
       "customType": "regex",
       "description": "Upgrade conda dependencies",
-      "managerFilePatterns": ["/(^|/)environment(.*).ya?ml$/"],
+      "managerFilePatterns": [
+        "/(^|/)environment(.*).ya?ml$/"
+      ],
       "matchStrings": [
         "#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?",
         "# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
@@ -67,7 +71,9 @@
     {
       "customType": "regex",
       "description": "Upgrade pypi dependencies inside conda environment files",
-      "managerFilePatterns": ["/(^|/)environment(.*).ya?ml$/"],
+      "managerFilePatterns": [
+        "/(^|/)environment(.*).ya?ml$/"
+      ],
       "matchStrings": [
         "# renovate datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
         "# renovate: datasource=pypi\\s+-\\s*(?<depName>[\\w-]+)\\s*(\\[[\\w,\\s]+\\])?\\s*==?\\s*(?<currentValue>.*)",
@@ -78,7 +84,9 @@
     {
       "customType": "regex",
       "description": "Upgrade arbitrary go module versions in Makefiles",
-      "managerFilePatterns": ["/^Makefile/"],
+      "managerFilePatterns": [
+        "/^Makefile/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
@@ -86,18 +94,26 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["custom.regex"],
+      "matchManagers": [
+        "custom.regex"
+      ],
       "commitMessageTopic": "{{datasource}} dependency {{depName}}"
     },
     {
       "description": "Widen ranges for terraform required_providers instead of replacing/bumping them. This preserves the minimum version",
-      "matchManagers": ["terraform"],
-      "matchDepTypes": ["required_provider"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "required_provider"
+      ],
       "rangeStrategy": "widen"
     },
     {
       "description": "Pin Serverless to less than 4.x because of license changes.",
-      "matchDepNames": ["serverless"],
+      "matchDepNames": [
+        "serverless"
+      ],
       "allowedVersions": "< 4.0"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
   ],
   "packageRules": [
     {
-      "matchFileNames": ["docs/**.md"],
+      "matchFileNames": [
+        "docs/**.md"
+      ],
       "automerge": true
     }
   ]

--- a/terraformModule.json
+++ b/terraformModule.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "description": "Automatically merge minor updates for some managers",
-      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "regex", "tflint-plugin"],
+      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "custom.regex", "tflint-plugin"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }

--- a/terraformModule.json
+++ b/terraformModule.json
@@ -6,8 +6,19 @@
   "packageRules": [
     {
       "description": "Automatically merge minor updates for some managers",
-      "matchManagers": ["github-actions", "pre-commit", "gomod", "dockerfile", "custom.regex", "tflint-plugin"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": [
+        "github-actions",
+        "pre-commit",
+        "gomod",
+        "dockerfile",
+        "custom.regex",
+        "tflint-plugin"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Description/Purpose

While renovate proposes migration PRs to the default configs like ./renovate.json in repos, it does not migrate the additional configs, which repos like this store. This can be achieved via the renovate pre-commit hook in [strict mode](https://docs.renovatebot.com/config-validation/#strict-mode) that detects not yet done migrations and also spits out how the config looks after migration.

This PR:
* enables the renovate-config-validator hook in strict mode for all renovate configs in the repo
* Incorporates the proposed migrations
* Formats all the configs for easier edits  / incorporating future migrations

## Expected Impact

Renovate should work as before.

Items like `customManagers:githubActionsVersions` become easier to look up in documentation as `regexManagers:githubActionsVersions` does not exist there anymore.