### PR TITLE
feat: enable pre-commit language version upgrades, pin go for terraform to 1.24.6

### DIFF
--- a/default.json
+++ b/default.json
@@ -90,6 +90,16 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s.*@(?<currentValue>.*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Enable pinning of default_language_version for pre-commit",
+      "managerFilePatterns": [
+        ".pre-commit-config.yaml"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?)\\sdepName=(?<depName>.*?)\\s*[a-z]*: (?<currentValue>[^\\s]+)"
+      ]
     }
   ],
   "packageRules": [

--- a/terraformModule.json
+++ b/terraformModule.json
@@ -23,6 +23,17 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Strip 'go' from go version, also pin to 1.24.6. Once https://github.com/golang/go/issues/74462 or https://github.com/gruntwork-io/terratest/issues/1589 is fixed, remove pin to 1.24.6",
+      "matchDatasources": [
+        "git-tags"
+      ],
+      "matchDepNames": [
+        "golang/go"
+      ],
+      "extractVersion": "^go(?<version>.*)$",
+      "allowedVersions": "1.24.6"
     }
   ]
 }


### PR DESCRIPTION
## Description/Purpose

Enable pre-commit "default_language_version" upgrades.

Also pins go for our terraform modules to 1.24.6 since we're affected by https://github.com/golang/go/issues/74462 due to the indirect dependency on x/tools 0.22.0 due to [terratest depending on it](https://github.com/gruntwork-io/terratest/blob/a4af63b232a8d830fb41d3781ebae29add27e57a/go.mod#L217).

## Expected Impact

CI works again.
