### PR TITLE
CORE-10021: exclude compromised versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -150,6 +150,16 @@
         "aquasecurity/trivy-action"
       ],
       "enabled": false
+    },
+    {
+      "description": "Block compromised axios versions 0.30.4 & 1.14.1. See https://osv.dev/vulnerability/MAL-2026-2307",
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "axios"
+      ],
+      "allowedVersions": "!/^(0\\.30\\.4|1\\.14\\.1)$/"
     }
   ],
   "schedule": [


### PR DESCRIPTION
## Description/Purpose

CORE-10021. Exclude compromised versions.

See https://osv.dev/vulnerability/MAL-2026-2307.

## Expected Impact

Malicious versions are not proposed if they're still around somewhere.
